### PR TITLE
E0-F1-S3-T1: Create git-repo conftest.py fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,3 +81,60 @@ def setup_user_identity(monkeysession, scope="session"):
     monkeysession.setenv("GIT_COMMITTER_NAME", "Foo Bar")
     monkeysession.setenv("GIT_AUTHOR_EMAIL", "foo@bar.baz")
     monkeysession.setenv("GIT_COMMITTER_EMAIL", "foo@bar.baz")
+
+
+@pytest.fixture
+def mock_manifest_xml(tmp_path):
+    """Create a temporary manifest XML file for testing.
+
+    Returns the path to a temporary file containing a minimal but valid
+    repo manifest XML document with a remote, default, and project element.
+
+    Args:
+        tmp_path: pytest built-in fixture providing a temporary directory
+            unique to each test invocation.
+
+    Returns:
+        str: Absolute path to the temporary manifest XML file.
+
+    Example usage::
+
+        def test_parse_manifest(mock_manifest_xml):
+            tree = ET.parse(mock_manifest_xml)
+            root = tree.getroot()
+            assert root.tag == "manifest"
+    """
+    manifest_content = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        "<manifest>\n"
+        '  <remote name="origin" fetch="https://example.com" />\n'
+        '  <default revision="main" remote="origin" sync-j="4" />\n'
+        '  <project name="platform/build" path="build" />\n'
+        "</manifest>\n"
+    )
+    manifest_file = tmp_path / "manifest.xml"
+    manifest_file.write_text(manifest_content)
+    return str(manifest_file)
+
+
+@pytest.fixture
+def mock_project_config():
+    """Return a mock project configuration dictionary for testing.
+
+    Provides a minimal project configuration dict with the standard keys
+    used throughout the git-repo codebase: name, path, remote, and revision.
+
+    Returns:
+        dict: A dictionary with keys 'name', 'path', 'remote', and 'revision'.
+
+    Example usage::
+
+        def test_project_name(mock_project_config):
+            assert mock_project_config["name"] == "platform/build"
+    """
+    return {
+        "name": "platform/build",
+        "path": "build",
+        "remote": "origin",
+        "revision": "main",
+    }

--- a/tests/test_conftest_fixtures.py
+++ b/tests/test_conftest_fixtures.py
@@ -1,0 +1,75 @@
+"""Tests for conftest.py shared fixtures.
+
+Validates that mock_manifest_xml and mock_project_config fixtures
+are available, use tmp_path for isolation, and return expected data.
+
+Spec Reference: Plan: Test harness — tests/conftest.py with shared fixtures.
+"""
+
+import os
+
+import pytest
+
+
+@pytest.mark.unit
+def test_mock_manifest_xml_fixture(mock_manifest_xml):
+    """Verify mock_manifest_xml fixture returns valid XML content.
+
+    Given: conftest.py provides a mock_manifest_xml fixture
+    When: A test requests the fixture
+    Then: It receives a path to a file containing valid manifest XML
+    Spec: Plan: Test harness
+    """
+    assert os.path.isfile(mock_manifest_xml), (
+        f"mock_manifest_xml must return a path to an existing file: {mock_manifest_xml}"
+    )
+    with open(mock_manifest_xml) as f:
+        content = f.read()
+    assert "<?xml" in content, "Manifest XML must contain XML declaration"
+    assert "<manifest>" in content, (
+        "Manifest XML must contain <manifest> element"
+    )
+    assert "<remote" in content, "Manifest XML must contain <remote> element"
+    assert "<project" in content, "Manifest XML must contain <project> element"
+
+
+@pytest.mark.unit
+def test_mock_project_config_fixture(mock_project_config):
+    """Verify mock_project_config fixture returns a valid config dict.
+
+    Given: conftest.py provides a mock_project_config fixture
+    When: A test requests the fixture
+    Then: It receives a dict with expected project config keys
+    Spec: Plan: Test harness
+    """
+    assert isinstance(mock_project_config, dict), (
+        f"mock_project_config must return a dict, got {type(mock_project_config)}"
+    )
+    assert "name" in mock_project_config, "Config must contain 'name' key"
+    assert "path" in mock_project_config, "Config must contain 'path' key"
+    assert "remote" in mock_project_config, "Config must contain 'remote' key"
+    assert "revision" in mock_project_config, (
+        "Config must contain 'revision' key"
+    )
+
+
+@pytest.mark.unit
+def test_fixtures_use_tmp_path(mock_manifest_xml, tmp_path):
+    """Verify that fixtures use tmp_path for test isolation.
+
+    Given: conftest.py fixtures use tmp_path
+    When: A test checks the fixture output location
+    Then: The file is located under the tmp_path hierarchy
+    Spec: Plan: Test harness
+    """
+    # mock_manifest_xml should be within a temporary directory
+    assert os.path.isfile(mock_manifest_xml), (
+        f"mock_manifest_xml must be a real file: {mock_manifest_xml}"
+    )
+    # The file should not be in the repo tree — it should be in a temp dir
+    repo_root = os.path.join(os.path.dirname(__file__), os.pardir)
+    real_repo = os.path.realpath(repo_root)
+    real_file = os.path.realpath(mock_manifest_xml)
+    assert not real_file.startswith(real_repo), (
+        f"Fixture file should be in a temp directory, not in repo tree: {real_file}"
+    )


### PR DESCRIPTION
## Summary
- Add `mock_manifest_xml` fixture to tests/conftest.py (returns temp file with valid manifest XML)
- Add `mock_project_config` fixture to tests/conftest.py (returns project config dict)
- Add tests/test_conftest_fixtures.py validating fixture behavior and tmp_path isolation

## Test plan
- [x] 3 new fixture tests pass
- [x] 315 existing tests still pass (318 total)
- [x] All 4 judge reviews passed