### PR TITLE
E0-F1-S3-T2: Create git-repo Test Fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,9 @@
 
 """Common fixtures for pytests."""
 
+import json
 import pathlib
+import shutil
 
 import pytest
 
@@ -83,12 +85,16 @@ def setup_user_identity(monkeysession, scope="session"):
     monkeysession.setenv("GIT_COMMITTER_EMAIL", "foo@bar.baz")
 
 
+_FIXTURES_DIR = pathlib.Path(__file__).parent / "fixtures"
+
+
 @pytest.fixture
 def mock_manifest_xml(tmp_path):
-    """Create a temporary manifest XML file for testing.
+    """Create a temporary copy of the sample manifest XML for testing.
 
-    Returns the path to a temporary file containing a minimal but valid
-    repo manifest XML document with a remote, default, and project element.
+    Copies the golden fixture file ``tests/fixtures/sample-manifest.xml``
+    into a temporary directory so tests can modify it without affecting
+    the original.
 
     Args:
         tmp_path: pytest built-in fixture providing a temporary directory
@@ -104,25 +110,19 @@ def mock_manifest_xml(tmp_path):
             root = tree.getroot()
             assert root.tag == "manifest"
     """
-    manifest_content = (
-        '<?xml version="1.0" encoding="UTF-8"?>\n'
-        "<manifest>\n"
-        '  <remote name="origin" fetch="https://example.com" />\n'
-        '  <default revision="main" remote="origin" sync-j="4" />\n'
-        '  <project name="platform/build" path="build" />\n'
-        "</manifest>\n"
-    )
-    manifest_file = tmp_path / "manifest.xml"
-    manifest_file.write_text(manifest_content)
-    return str(manifest_file)
+    source = _FIXTURES_DIR / "sample-manifest.xml"
+    dest = tmp_path / "manifest.xml"
+    shutil.copy2(source, dest)
+    return str(dest)
 
 
 @pytest.fixture
 def mock_project_config():
-    """Return a mock project configuration dictionary for testing.
+    """Return a project configuration dictionary loaded from the fixture file.
 
-    Provides a minimal project configuration dict with the standard keys
-    used throughout the git-repo codebase: name, path, remote, and revision.
+    Loads ``tests/fixtures/sample-project-config.json`` and returns the
+    parsed dictionary with standard keys used throughout the git-repo
+    codebase: name, path, remote, and revision.
 
     Returns:
         dict: A dictionary with keys 'name', 'path', 'remote', and 'revision'.
@@ -132,9 +132,6 @@ def mock_project_config():
         def test_project_name(mock_project_config):
             assert mock_project_config["name"] == "platform/build"
     """
-    return {
-        "name": "platform/build",
-        "path": "build",
-        "remote": "origin",
-        "revision": "main",
-    }
+    config_path = _FIXTURES_DIR / "sample-project-config.json"
+    with open(config_path) as f:
+        return json.load(f)

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -1,0 +1,20 @@
+# Test Fixtures
+
+Golden reference files for git-repo test suite.
+
+## Files
+
+| File | Format | Purpose |
+|---|---|---|
+| `sample-manifest.xml` | XML | Representative repo tool manifest with remotes, defaults, and projects. Used by `conftest.py::mock_manifest_xml` and manifest parsing tests. |
+| `sample-project-config.json` | JSON | Representative project configuration with name, path, remote, and revision fields. Used by `conftest.py::mock_project_config` and project config tests. |
+| `linter-test-bad.md` | Markdown | Intentionally invalid Markdown for markdownlint config testing (E0-F1-S2-T2). |
+| `linter-test-bad.yml` | YAML | Intentionally invalid YAML for yamllint config testing (E0-F1-S2-T3). |
+| `linter-test-bad.py` | Python | Intentionally invalid Python for ruff config testing (E0-F1-S2-T1). |
+| `test.gitconfig` | Git config | Git configuration fixture for upstream tests. |
+
+## Conventions
+
+- Fixture files are **golden files** — their content is the expected reference.
+- Do not modify fixture files without updating corresponding tests.
+- New fixtures should be documented in this table.

--- a/tests/fixtures/sample-manifest.xml
+++ b/tests/fixtures/sample-manifest.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Sample repo tool manifest XML for testing.
+  This is a golden fixture file representing a typical multi-project manifest.
+  See tests/fixtures/README.md for details.
+-->
+<manifest>
+  <remote name="origin"
+          fetch="https://example.com"
+          review="https://example.com/review" />
+
+  <default revision="main"
+           remote="origin"
+           sync-j="4" />
+
+  <project name="platform/build"
+           path="build"
+           groups="pdk" />
+
+  <project name="platform/tools"
+           path="tools"
+           revision="refs/tags/v1.0.0" />
+</manifest>

--- a/tests/fixtures/sample-project-config.json
+++ b/tests/fixtures/sample-project-config.json
@@ -1,0 +1,9 @@
+{
+  "name": "platform/build",
+  "path": "build",
+  "remote": "origin",
+  "revision": "main",
+  "groups": ["pdk"],
+  "sync-c": false,
+  "sync-s": false
+}

--- a/tests/test_fixture_files.py
+++ b/tests/test_fixture_files.py
@@ -1,0 +1,82 @@
+"""Tests for test fixture files in tests/fixtures/.
+
+Validates that golden fixture files are syntactically valid
+and loadable by conftest.py fixtures.
+
+Spec Reference: Plan: Per-Repo Tooling — tests/fixtures/ with initial test data.
+"""
+
+import json
+import os
+import xml.etree.ElementTree as ET
+
+import pytest
+
+FIXTURES_DIR = os.path.join(os.path.dirname(__file__), "fixtures")
+
+
+@pytest.mark.unit
+def test_fixture_files_exist():
+    """Verify all planned fixture files exist.
+
+    Given: tests/fixtures/ directory exists
+    When: We check for required fixture files
+    Then: sample-manifest.xml, sample-project-config.json, and README.md all exist
+    Spec: Plan: Test fixtures
+    """
+    expected_files = [
+        "sample-manifest.xml",
+        "sample-project-config.json",
+        "README.md",
+    ]
+    for filename in expected_files:
+        filepath = os.path.join(FIXTURES_DIR, filename)
+        assert os.path.isfile(filepath), (
+            f"Required fixture file missing: {filepath}"
+        )
+
+
+@pytest.mark.unit
+def test_sample_manifest_valid_xml():
+    """Verify sample-manifest.xml is well-formed XML.
+
+    Given: tests/fixtures/sample-manifest.xml exists
+    When: Parsed as XML
+    Then: Parsing succeeds and root element is <manifest>
+    Spec: Plan: Test fixtures
+    """
+    manifest_path = os.path.join(FIXTURES_DIR, "sample-manifest.xml")
+    tree = ET.parse(manifest_path)
+    root = tree.getroot()
+    assert root.tag == "manifest", (
+        f"Root element must be <manifest>, got <{root.tag}>"
+    )
+    remotes = root.findall("remote")
+    assert len(remotes) > 0, (
+        "Manifest must contain at least one <remote> element"
+    )
+    projects = root.findall("project")
+    assert len(projects) > 0, (
+        "Manifest must contain at least one <project> element"
+    )
+
+
+@pytest.mark.unit
+def test_sample_project_config_valid_json():
+    """Verify sample-project-config.json is valid JSON.
+
+    Given: tests/fixtures/sample-project-config.json exists
+    When: Parsed as JSON
+    Then: Parsing succeeds and contains expected keys
+    Spec: Plan: Test fixtures
+    """
+    config_path = os.path.join(FIXTURES_DIR, "sample-project-config.json")
+    with open(config_path) as f:
+        config = json.load(f)
+    assert isinstance(config, dict), (
+        f"Config must be a JSON object, got {type(config)}"
+    )
+    assert "name" in config, "Config must contain 'name' key"
+    assert "path" in config, "Config must contain 'path' key"
+    assert "remote" in config, "Config must contain 'remote' key"
+    assert "revision" in config, "Config must contain 'revision' key"


### PR DESCRIPTION
## Summary
- Add `tests/fixtures/sample-manifest.xml` (golden reference manifest XML)
- Add `tests/fixtures/sample-project-config.json` (golden reference project config)
- Add `tests/fixtures/README.md` documenting all fixture files
- Add `tests/test_fixture_files.py` validating fixture file integrity
- Update `tests/conftest.py` to load fixtures from files instead of inline data

## Test plan
- [x] 3 new fixture validation tests pass
- [x] 321 total tests pass (no regression)
- [x] All 4 judge reviews passed